### PR TITLE
enable mergequeue

### DIFF
--- a/otterdog/eclipse-openbsw.jsonnet
+++ b/otterdog/eclipse-openbsw.jsonnet
@@ -34,6 +34,30 @@ orgs.newOrg('automotive.openbsw', 'eclipse-openbsw') {
       gh_pages_build_type: "legacy",
       gh_pages_source_branch: "gh-pages",
       gh_pages_source_path: "/",
+      rulesets: [
+        orgs.newRepoRuleset('main') {
+          include_refs+: [
+            "~DEFAULT_BRANCH",
+          ],
+          required_pull_request+: {
+            required_approving_review_count: 1,
+            dismisses_stale_reviews: true,
+          },
+          required_status_checks+: {
+            status_checks: [
+              "build-executable",
+              "code-coverage",
+              "doxygen-build",
+              "treefmt",
+              "sphinx-doc-build",
+            ],
+          },
+          requires_linear_history: true,
+          required_merge_queue: orgs.newMergeQueue() {
+            merge_method: "SQUASH",
+          },
+        }
+      ],
     },
   ],
 }


### PR DESCRIPTION
Merge queues could help us ensure, that we don't break the main branch.
It enables us to run checks right before a PR is merged. This way it will be detected if a PR needs to be rebased.

More info:
[1 minute long intro Video](https://www.youtube.com/watch?v=XEZMgohmtts)
[GH docs](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue)
